### PR TITLE
Fix undetected disconnects for any non-TinyGo BluetoothClient

### DIFF
--- a/internal/core/bluetooth_manager.go
+++ b/internal/core/bluetooth_manager.go
@@ -56,8 +56,17 @@ func (bm *BluetoothManager) SetClient(client BluetoothClient) {
 
 // setupPhaseCallback sets up the phase change and connection-lost callbacks on
 // the Bluetooth client.
+// phaseAwareClient is the capability subset of a BluetoothClient that can
+// report connection-phase transitions and unsolicited disconnects. Asserting
+// against this rather than a concrete type lets any client -- including one
+// installed with SetClient -- receive the callbacks.
+type phaseAwareClient interface {
+	SetPhaseChangeCallback(callback func(ConnectionPhase))
+	SetConnectionLostCallback(callback func())
+}
+
 func (bm *BluetoothManager) setupPhaseCallback() {
-	if tinyGoClient, ok := bm.bluetoothClient.(*TinyGoBluetoothClient); ok {
+	if tinyGoClient, ok := bm.bluetoothClient.(phaseAwareClient); ok {
 		tinyGoClient.SetPhaseChangeCallback(func(phase ConnectionPhase) {
 			switch phase {
 			case PhaseScanning:


### PR DESCRIPTION
## The problem

`BluetoothManager.setupPhaseCallback()` asserts the **concrete** type before installing the phase-change and connection-lost callbacks:

```go
if tinyGoClient, ok := bm.bluetoothClient.(*TinyGoBluetoothClient); ok {
    tinyGoClient.SetPhaseChangeCallback(...)
    tinyGoClient.SetConnectionLostCallback(bm.handleConnectionLost)
}
```

Any other client installed via `SetClient` fails that assertion **silently** and never receives either callback — including `SimulatorBluetoothClient`, `MockBluetoothClient`, and any platform-specific transport.

The consequence isn't cosmetic. `handleConnectionLost` is what resets connection status, battery level and display name, and drives `LaunchMonitor`'s teardown on an unsolicited disconnect. Without it, a device that powers off or goes out of range leaves the app believing it is still connected — the app's own `ARCHITECTURE_REVIEW.md` calls undetected disconnects out as a real-world gap, and this is the mechanism.

It's also silent by construction: `ok` is simply `false`, so there is no log line and nothing to notice.

## The change

Assert against the capability instead of the concrete type:

```go
type phaseAwareClient interface {
    SetPhaseChangeCallback(callback func(ConnectionPhase))
    SetConnectionLostCallback(callback func())
}
```

`*TinyGoBluetoothClient` already satisfies it, so **behaviour on the existing path is unchanged** and no existing test moves. Any client that wants the callbacks can now opt in just by implementing the two methods; clients that don't are unaffected.

One file, +10/-1.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/...` — 7 packages pass, no change from before
- Also exercised via a non-TinyGo client, which now receives `handleConnectionLost` where previously it received nothing

## Context

Found while porting the connector to Android, where the BLE transport is supplied by the platform rather than by TinyGo, so this assertion excluded it entirely. The fix is general rather than Android-specific, which is why it's offered on its own.
