### PR TITLE
Fix GSPro Open Connect message framing, and stop wedging its listener on disconnect

### DIFF
--- a/internal/core/simulator/connection.go
+++ b/internal/core/simulator/connection.go
@@ -32,6 +32,10 @@ type Base struct {
 	ReconnectAttempts  int
 	LastConnectAttempt time.Time
 	backoff            *resilience.Backoff
+
+	// sendMutex serialises SendMessage and, with lastSendAt, enforces minSendGap.
+	sendMutex  sync.Mutex
+	lastSendAt time.Time
 }
 
 func NewBase(protocol Protocol, host string, port int) *Base {
@@ -123,6 +127,25 @@ func (b *Base) Disconnect() {
 
 	_ = b.Socket.SetDeadline(time.Now().Add(2 * time.Second))
 
+	// Close with RST rather than a graceful FIN.
+	//
+	// GSPro Connect's accept loop only calls AcceptTcpClient() when its current
+	// client looks disconnected, and its read loop never checks Read()'s return
+	// value. A graceful FIN therefore gives it an endless stream of zero-length
+	// reads on a socket it still believes is live: it spins, never re-accepts, and
+	// every later connection attempt is refused until the process is restarted.
+	// Observed directly - two sockets left in CLOSE_WAIT and a dead listener.
+	//
+	// SetLinger(0) sends RST instead, which surfaces as an exception in its reader
+	// and takes the teardown path that does re-accept. Nothing is lost: we only
+	// reach here after deciding to drop the connection, and any unsent data would
+	// have been discarded anyway.
+	if tcp, ok := b.Socket.(*net.TCPConn); ok {
+		if err := tcp.SetLinger(0); err != nil {
+			log.Printf("[%s] Could not set SO_LINGER, closing with FIN: %v", b.Protocol.Name(), err)
+		}
+	}
+
 	if b.Socket != nil {
 		err := b.Socket.Close()
 		if err != nil {
@@ -200,13 +223,44 @@ func (b *Base) ResetReconnectionState() {
 	log.Printf("[%s] Reconnection state reset", b.Protocol.Name())
 }
 
+// minSendGap is the minimum wall-clock spacing between two outbound messages.
+//
+// This is rate limiting, not sequencing. GSPro Connect's reader performs a single
+// Read() into an SO_RCVBUF-sized buffer, ASCII-decodes the whole buffer and parses
+// it with CheckAdditionalContent enabled. Two messages that arrive before it drains
+// that buffer therefore reach the parser concatenated, and it answers
+// {"Code":501,"Message":"Bad format"} - dropping both.
+//
+// This is easy to hit: the ball-data and club-data writes for a single shot are
+// issued about a millisecond apart and coalesce reliably on loopback. TCP_NODELAY
+// does not help; even as separate segments both messages sit in the receive buffer
+// before the peer's next Read().
+//
+// Verified against GSPro Connect v3.2.50: byte-identical payloads returned 501 when
+// written together and 200 when written apart.
+const minSendGap = 250 * time.Millisecond
+
 func (b *Base) SendMessage(data []byte) error {
+	// Serialise writers as well as pace them: concurrent callers previously raced
+	// on Socket.Write with no lock at all.
+	b.sendMutex.Lock()
+	defer b.sendMutex.Unlock()
+
 	if !b.Connected || b.Socket == nil {
 		return fmt.Errorf("not connected to %s", b.Protocol.Name())
 	}
 
+	if wait := minSendGap - time.Since(b.lastSendAt); wait > 0 {
+		time.Sleep(wait)
+		// Connected may have changed while we waited.
+		if !b.Connected || b.Socket == nil {
+			return fmt.Errorf("not connected to %s", b.Protocol.Name())
+		}
+	}
+
 	message := append(data, '\n')
 	_, err := b.Socket.Write(message)
+	b.lastSendAt = time.Now()
 	if err != nil {
 		b.Disconnect()
 		return fmt.Errorf("error sending data: %w", err)

--- a/internal/core/simulator/connection.go
+++ b/internal/core/simulator/connection.go
@@ -92,6 +92,25 @@ func (b *Base) Connect(host string, port int) {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetKeepAlivePeriod(30 * time.Second)
 		log.Printf("[%s] TCP keepalive enabled", b.Protocol.Name())
+
+		// Close this socket with RST rather than a graceful FIN, and set that
+		// now rather than at Disconnect so it holds however the socket dies -
+		// including the implicit close when the OS reaps the process.
+		//
+		// GSPro Connect only calls AcceptTcpClient() when its current client
+		// looks disconnected, and its read loop never checks Read()'s return
+		// value. A FIN gives it endless zero-length reads on a socket it still
+		// believes is live: it spins, never re-accepts, and every later
+		// connection is refused until it is restarted by hand. An RST instead
+		// surfaces as an exception in its reader and takes the teardown path
+		// that does re-accept.
+		//
+		// Setting it at Disconnect alone would only cover a graceful shutdown,
+		// which is the case that matters least on a phone - an Android app is
+		// far more likely to be killed in the background than to exit cleanly.
+		if err := tcpConn.SetLinger(0); err != nil {
+			log.Printf("[%s] Could not set SO_LINGER; close will send FIN: %v", b.Protocol.Name(), err)
+		}
 	}
 
 	b.Socket = conn
@@ -127,24 +146,8 @@ func (b *Base) Disconnect() {
 
 	_ = b.Socket.SetDeadline(time.Now().Add(2 * time.Second))
 
-	// Close with RST rather than a graceful FIN.
-	//
-	// GSPro Connect's accept loop only calls AcceptTcpClient() when its current
-	// client looks disconnected, and its read loop never checks Read()'s return
-	// value. A graceful FIN therefore gives it an endless stream of zero-length
-	// reads on a socket it still believes is live: it spins, never re-accepts, and
-	// every later connection attempt is refused until the process is restarted.
-	// Observed directly - two sockets left in CLOSE_WAIT and a dead listener.
-	//
-	// SetLinger(0) sends RST instead, which surfaces as an exception in its reader
-	// and takes the teardown path that does re-accept. Nothing is lost: we only
-	// reach here after deciding to drop the connection, and any unsent data would
-	// have been discarded anyway.
-	if tcp, ok := b.Socket.(*net.TCPConn); ok {
-		if err := tcp.SetLinger(0); err != nil {
-			log.Printf("[%s] Could not set SO_LINGER, closing with FIN: %v", b.Protocol.Name(), err)
-		}
-	}
+	// SO_LINGER 0 was set in Connect, so this Close sends RST rather than FIN and
+	// does not wedge GSPro Connect's accept loop. See the comment there.
 
 	if b.Socket != nil {
 		err := b.Socket.Close()

--- a/internal/plugins/connectapi/data_conversion.go
+++ b/internal/plugins/connectapi/data_conversion.go
@@ -30,7 +30,14 @@ func (g *Integration) convertToShotFormat(ballMetrics protocol.BallMetrics, incr
 			HLA:       ballMetrics.HorizontalAngle,
 			VLA:       ballMetrics.VerticalAngle,
 		},
-		ClubData: &ClubData{}, // Empty club data
+		// Deliberately nil, not &ClubData{}: ShotData tags this field omitempty,
+		// which only skips a NIL pointer. An empty struct still marshals, so every
+		// ball message carried ten zeroed club fields alongside
+		// ContainsClubData:false - contradicting itself and wasting the payload.
+		//
+		// Both club-data paths in listeners.go assign ClubData themselves before
+		// sending, so nothing downstream depends on this being non-nil.
+		ClubData: nil,
 	}
 }
 


### PR DESCRIPTION
Three related fixes found while running the connector against GSPro Connect **v3.2.50**. All three are timing/protocol issues rather than logic errors, which is why they're intermittent (or invisible) on a fast desktop and reliable on slower hardware.

Each is a separate commit and they're independent — happy to split into separate PRs if you'd prefer.

---

## 1. Two messages in one TCP segment are rejected as `Bad format`

GSPro Connect's reader performs a **single** `Read()` into an `SO_RCVBUF`-sized buffer, ASCII-decodes the whole buffer, and parses it with `CheckAdditionalContent` enabled. Two messages that arrive before it drains the buffer therefore reach the parser concatenated, and it answers:

```json
{"Code":501,"Message":"Bad format","Player":null}
```

…dropping **both**.

`connectapi` issues the ball-data and club-data writes for a single shot about a millisecond apart, so they coalesce reliably. The visible symptom is that **shots lose their ball data entirely** — only the trailing club write, a second later, arrives alone and is accepted.

Demonstrated directly against the real connector — byte-identical payloads, the only variable being whether they shared a write:

```
two objects, ONE write  -> {"Code":501,"Message":"Bad format"}
one object,  own write  -> {"Code":200,"Message":"Ball Data received"}
```

`SendMessage` now serialises and paces writes with a 250 ms floor. Worth noting **`TCP_NODELAY` is not a fix**: even as separate segments, both messages sit in the receive buffer before the peer's next `Read()`.

Waiting for the previous ack isn't viable either — `Code 200` is emitted from a 200 ms UI timer and *coalesces*, so two quick shots produce one ack.

## 2. `SendMessage` had no lock

Concurrent callers raced on `Socket.Write` with no synchronisation at all. Now serialised by the same mutex as the pacing. (Not observed in the wild, but it's a one-line consequence of fixing #1.)

## 3. A graceful close wedges GSPro Connect's listener until it is restarted

GSPro Connect only calls `AcceptTcpClient()` when its current client *looks* disconnected, and its read loop never checks `Read()`'s return value. A FIN therefore hands it an endless stream of zero-length reads on a socket it still believes is live: it spins, never re-accepts, and **every subsequent connection is refused until the process is restarted by hand**.

Observed directly — two sockets stuck in `CLOSE_WAIT` and a dead listener.

Setting `SO_LINGER 0` makes the close send RST instead, which surfaces as an exception in its reader and takes the teardown path that *does* re-accept.

It's set at **connect** rather than at disconnect deliberately, so it holds however the socket dies — including the implicit close when the OS reaps the process. Measured with the client killed outright:

```
before   two sockets in CLOSE_WAIT, listener dead, later connections refused
after    listener only, next client answered {"Code":200,"Message":"Ball Data received"}
```

## 4. Bonus: ball-only messages carried an empty `ClubData`

`ShotData` tags `ClubData` `omitempty`, but `omitempty` only skips a **nil** pointer — an empty struct still marshals. `convertToShotFormat` passed `&ClubData{}`, so every ball message carried ten zeroed club fields next to `ContainsClubData:false`, contradicting its own options block.

Both club-data paths in `listeners.go` assign `ClubData` themselves before sending, so nothing depended on it being non-nil. Confirmed accepted: the same payload with the object removed returns `200`.

---

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/...` — 7 packages pass, unchanged
- End-to-end against GSPro Connect v3.2.50: a shot of 30.4 m/s / 1.1° / 144 rpm now arrives and displays as **67.9 mph / VLA 1.1 / Spin 144**, where before the ball half was rejected

## Context

Found while running the connector on Android, where GSPro runs under Wine on the same device. The slower environment makes #1 and #3 reproduce every time, but neither is Android-specific — #1 is a race that a fast desktop usually wins, and #3 bites any client that disconnects and reconnects.

The 250 ms floor is a workaround for the peer's parser rather than a cure, so if you'd rather tune the constant or gate it behind a config key, very happy to adjust.
